### PR TITLE
Restoring indended default numbering to Rosetta/Foldit numbering

### DIFF
--- a/src/pages/database/BglB_characterization/index.tsx
+++ b/src/pages/database/BglB_characterization/index.tsx
@@ -45,7 +45,7 @@ function Page({ id, variant, wt_id}: { id: string, variant:string , wt_id:string
 
 const DataPage = () => {
   const [expandData, setExpandData] = useState(false);
-  const [useRosettaNumbering, setUseRosettaNumbering] = useState(false);
+  const [useRosettaNumbering, setUseRosettaNumbering] = useState(true);
   const [sequences, setSequences] = useState<any[]>([]);
   const [showNonCurated, setShowNonCurated] = useState(false); 
   const [institutions, setInstitutions] = useState<Institution[]>([]);


### PR DESCRIPTION
## Detailed Description
This change set should resolve Issue #89 

## Screenshots
### Before
<img width="885" height="368" alt="default numbering before" src="https://github.com/user-attachments/assets/ec5217e1-ab26-49ef-8831-71a1d46556dc" />

### After
<img width="704" height="318" alt="default numbering after" src="https://github.com/user-attachments/assets/030a8ef2-005c-482f-80b5-8317ca5abcaf" />

## **Checklist before requesting a review**
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A)
- [x] I need to delete the branch once I get the PR approved if a feature is done
- [x] I will include relevant pictures to better understand the PR
