### PR TITLE
Restoring proper .csv-file generation and adding new columns

### DIFF
--- a/src/pages/database/BglB_characterization/index.tsx
+++ b/src/pages/database/BglB_characterization/index.tsx
@@ -1220,8 +1220,7 @@ const DataPage = () => {
                             size="md"
                             onClick={downloadCSV}
                           >
-				Download filtered/displayed data<br></br>
-				<small>({displayData.length} records)</small><br></br>
+				Download filtered/displayed data<br />				
 				as comma-delimited file
                           </Button>
                         </div>

--- a/src/pages/database/BglB_characterization/index.tsx
+++ b/src/pages/database/BglB_characterization/index.tsx
@@ -1202,7 +1202,7 @@ const DataPage = () => {
                             size="md"
                             onClick={downloadCSV}
                           >
-                            Download curated data as <br></br> comma-delimited file
+                            Download data as <br /> comma-delimited file
                           </Button>
                         </div>
 

--- a/src/pages/database/BglB_characterization/index.tsx
+++ b/src/pages/database/BglB_characterization/index.tsx
@@ -1220,9 +1220,9 @@ const DataPage = () => {
                             size="md"
                             onClick={downloadCSV}
                           >
-                            Download filtered/displayed data<br />
-			    <br /><small>({displayData.length} records)</small><br />
-			    <br />as comma-delimited file
+				Download filtered/displayed data<br></br>br>
+				<small>({displayData.length} records)</small></br>br>
+				as comma-delimited file
                           </Button>
                         </div>
 

--- a/src/pages/database/BglB_characterization/index.tsx
+++ b/src/pages/database/BglB_characterization/index.tsx
@@ -734,11 +734,18 @@ const DataPage = () => {
 
   // Add this function near other utility functions
   const downloadCSV = () => {
-    // Only include curated data
-    const curatedData = characterizationData.filter(data => data.curated);
-    
+    // Generate a .csv file for download, based on current filter selections.
+
+	// TODO: Fix this duplicated code from above.
+	const filteredData = characterizationData
+      .filter(data => 
+        data.curated || 
+        (showNonCurated && !data.curated && data.submitted_for_curation)
+      )
+      .filter(data => !selectedInstitution || data.institution === selectedInstitution);
+	    
     // Sort data by resnum (not resid)
-    const sortedData = [...curatedData].sort((a, b) => {
+	const sortedData = [...filteredData].sort((a, b) => {
       // First, handle the WT (resid == 'X') cases
       if (a.resid === 'X' && b.resid !== 'X') return -1;
       if (a.resid !== 'X' && b.resid === 'X') return 1;
@@ -749,28 +756,34 @@ const DataPage = () => {
     
     // Define headers for CSV with plain text alternatives for special characters
     const headers = [
+	  'ID #',
       'Variant',
-      'Expressed',
+      'Induced?',
+      'Expressed?',
       'Yield (mg/mL)',
-      'KM (mᴍ)',
+      'KM (mM)',
       'KM SD',
-      'kcat (min^-1)',  // Changed from min⁻¹
+      'kcat (1/min)',
       'kcat SD',
-      'kcat/KM (mᴍ^-1min^-1)',  // Changed from mM⁻¹min⁻¹
+      'kcat/KM (1/(mM min))',
       'kcat/KM SD',
       'T50 (degrees C)',  // Changed from °C
       'T50 SD',
       'Tm (degrees C)',  // Changed from °C
       'Tm SD',
       'Rosetta score change',
-      'Institution'
+      'Institution',
+	  'Created by',
+	  'Curated?',
     ];
 
     // Transform data into CSV rows
     const csvRows = sortedData.map(data => {
       const variant = getVariantDisplay(data.resid, data.resnum, data.resmut);
       return [
+		data.id,
         variant,
+		'data not transfered from old site',  // TODO: Fix when databases are re-synced
         data.expressed ? 'yes' : 'no',
         (data.yield_avg !== null && !isNaN(data.yield_avg)) ? data.yield_avg : (data.expressed ? 'not reported' : ''),
         data.KM_avg || '',
@@ -784,7 +797,9 @@ const DataPage = () => {
         data.Tm || '',
         data.Tm_SD || '',
         data.Rosetta_score || '',
-        data.institution || ''
+        data.institution || '',
+	    data.creator || 'unknown',
+		data.curated ? 'yes' : 'no'
       ].join(',');
     });
 
@@ -796,7 +811,12 @@ const DataPage = () => {
     const link = document.createElement('a');
     const url = URL.createObjectURL(blob);
     link.setAttribute('href', url);
-    link.setAttribute('download', 'BglB_characterization_data.csv');
+	// showNonCurated
+//selectedInstitution
+    link.setAttribute('download',
+		'BglB_characterization_data' + 
+		(selectedInstitution ? "_" + selectedInstitution : "") +
+		(showNonCurated ? "" : "_curated") + '.csv');
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
@@ -1202,7 +1222,7 @@ const DataPage = () => {
                             size="md"
                             onClick={downloadCSV}
                           >
-                            Download data as <br /> comma-delimited file
+                            Download filtered/displayed data as <br /> comma-delimited file
                           </Button>
                         </div>
 

--- a/src/pages/database/BglB_characterization/index.tsx
+++ b/src/pages/database/BglB_characterization/index.tsx
@@ -1221,8 +1221,8 @@ const DataPage = () => {
                             onClick={downloadCSV}
                           >
                             Download filtered/displayed data<br />
-			    <small>({displayData.length} records)</small><br />
-			    as comma-delimited file
+			    <br /><small>({displayData.length} records)</small><br />
+			    <br />as comma-delimited file
                           </Button>
                         </div>
 

--- a/src/pages/database/BglB_characterization/index.tsx
+++ b/src/pages/database/BglB_characterization/index.tsx
@@ -1220,8 +1220,8 @@ const DataPage = () => {
                             size="md"
                             onClick={downloadCSV}
                           >
-                            Download filtered/displayed data <br />
-			    <small>({displayData.length} records)</small> <br />
+                            Download filtered/displayed data<br />
+			    <small>({displayData.length} records)</small><br />
 			    as comma-delimited file
                           </Button>
                         </div>

--- a/src/pages/database/BglB_characterization/index.tsx
+++ b/src/pages/database/BglB_characterization/index.tsx
@@ -1220,7 +1220,9 @@ const DataPage = () => {
                             size="md"
                             onClick={downloadCSV}
                           >
-                            Download filtered/displayed data as <br /> comma-delimited file
+                            Download filtered/displayed data <br />
+			    ({displayData.length} records) <br />
+			    as comma-delimited file
                           </Button>
                         </div>
 

--- a/src/pages/database/BglB_characterization/index.tsx
+++ b/src/pages/database/BglB_characterization/index.tsx
@@ -1221,7 +1221,7 @@ const DataPage = () => {
                             onClick={downloadCSV}
                           >
                             Download filtered/displayed data <br />
-			    ({displayData.length} records) <br />
+			    <small>({displayData.length} records)</small> <br />
 			    as comma-delimited file
                           </Button>
                         </div>

--- a/src/pages/database/BglB_characterization/index.tsx
+++ b/src/pages/database/BglB_characterization/index.tsx
@@ -811,8 +811,6 @@ const DataPage = () => {
     const link = document.createElement('a');
     const url = URL.createObjectURL(blob);
     link.setAttribute('href', url);
-	// showNonCurated
-//selectedInstitution
     link.setAttribute('download',
 		'BglB_characterization_data' + 
 		(selectedInstitution ? "_" + selectedInstitution : "") +

--- a/src/pages/database/BglB_characterization/index.tsx
+++ b/src/pages/database/BglB_characterization/index.tsx
@@ -1220,8 +1220,8 @@ const DataPage = () => {
                             size="md"
                             onClick={downloadCSV}
                           >
-				Download filtered/displayed data<br></br>br>
-				<small>({displayData.length} records)</small></br>br>
+				Download filtered/displayed data<br></br>
+				<small>({displayData.length} records)</small><br></br>
 				as comma-delimited file
                           </Button>
                         </div>


### PR DESCRIPTION
## Detailed Description
This change set restores the original intended behavior of how `.csv` files should be generated, specifically, to adhere to the current filter selections and to append designators to the filenames to indicate the major filter options.

This change set also adds the following columns, per request (#99):
- [x] Username
- [ ] Assay date
- [x] Currated/not-currated
- [x] ID number

Assay date has not yet been added, because that is not data saved with a variant. It is specific to each individual assay. Once issue #95 is resolved, a column for when the variant was submitted can be added. For now, one can sort by date roughly by sorting by ID.

<s>Additionally, this set shows the total number of records that will be downloaded when the button is clicked. (I do not like the style of the button itself, but that can be fixed later.)</s>