### PR TITLE
Fix Dashboard buttons so that they don't have to be clicked twice to submit a new dataset 

### DIFF
--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -323,12 +323,12 @@ const Dashboard = () => {
               {[
                 {
                   title: 'Single Variant',
-                  link: '/submit',
+                  link: '/submit/?single_variant=1',
                   linkText: 'Submit Data'
                 },
                 {
                   title: 'Wild Type',
-                  link: '/submit',
+                  link: '/submit/?wild_type=1',
                   linkText: 'Submit Data'
                 },
                 {

--- a/src/pages/submit/index.tsx
+++ b/src/pages/submit/index.tsx
@@ -126,6 +126,20 @@ const SubmitPage = () => {
     }
   };
 
+  // Add an effect to initialize filters from URL on page load.
+  useEffect(() => {
+    // Wait for router to be ready.
+    if (!router.isReady) return;
+    
+    const { 
+      single_variant, 
+      wild_type, 
+    } = router.query;
+    
+    // Set initial selection of submission type.
+    if (single_variant !== undefined) setSelection('single_variant');
+    if (wild_type !== undefined) setSelection('wild_type');
+  }, [router.isReady, router.query]);
 
   // for new dataset navigation to work 
   useEffect(() => {


### PR DESCRIPTION
## Detailed Description

This change set corrects an issue where clicking on either the "Single Variant" or "Wild Type" button/tile from the Dashboard took one to the "Data Analysis & Submission" page where the same buttons would have to be clicked a second time. Now, clicking from the Dashboard adds a param to the URL to skip directly to the proper subpage.

This PR will close issue #88.