### PR TITLE
Exporting Dates in .csv File

### DIFF
--- a/src/pages/database/BglB_characterization/index.tsx
+++ b/src/pages/database/BglB_characterization/index.tsx
@@ -911,6 +911,8 @@ const DataPage = () => {
       'Rosetta score change',
       'Institution',
 	    'Created by',
+      'Date created',
+      'Date submitted',
 	    'Curated?',
     ];
 
@@ -940,6 +942,8 @@ const DataPage = () => {
         data.Rosetta_score || '',
         data.institution || '',
 	      data.creator || 'unknown',
+        data.created_date,
+        data.submitted_date || 'not submitted',
 	      data.curated ? 'yes' : 'no'
       ].join(',');
     });


### PR DESCRIPTION
## Detailed Description
This quick change set simply adds code to export "created on" and "submitted for curation on" dates to the exported `.csv` file.

Separately, a Python script was used to perform the following:

- Most (but not all) of the dates in the database for the raw data have been changed to the YYYY.MM.DD format. (These values don't matter for anything.)
- Data records added since December 15 already had “created on” and “submitted for curation” dates.
- I used the publication date of 2017.05.22 for the “created on” dates for the Carlin records and left the “submitted for curation” dates blank.
- For all the rest, I used the earliest date of purification for a set of assays and the latest date of assay for a set to estimate the “created on” and “submitted for” curation dates, respectively.
- I had to manually correct a bunch of dates, where people had flipped days and months and such. I cannot promise I caught them all, but I caught any where the month for the “created on” or “submitted for curation” date was greater than 12, because the database won't allow that.
