### PR TITLE
Adding and Removing "Manage" Buttons

### DIFF
--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -356,7 +356,7 @@ const Dashboard = () => {
 						{/* Action Cards Section */}
 						<div
 							className={`grid gap-6 mb-20 ${
-								user?.status === 'ADMIN' || user?.status === 'PROFESSOR'
+								user?.status === 'ADMIN' || user?.status === 'professor'
 									? 'grid-cols-1 md:grid-cols-2 lg:grid-cols-4'
 									: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3'
 							}`}
@@ -377,7 +377,7 @@ const Dashboard = () => {
 									link: '/submit/gel_image_upload',
 									linkText: 'Upload Image'
 								},
-								...(user?.status === 'ADMIN' || user?.status === 'PROFESSOR'
+								...(user?.status === 'ADMIN' || user?.status === 'professor'
 									? [
 											{
 												title: 'Curate',

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -355,11 +355,8 @@ const Dashboard = () => {
 
 						{/* Action Cards Section */}
 						<div
-							className={`grid gap-6 mb-20 ${
-								user?.status === 'ADMIN' || user?.status === 'professor'
-									? 'grid-cols-1 md:grid-cols-2 lg:grid-cols-4'
-									: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3'
-							}`}
+							className='grid gap-6 mb-20 grid-cols-1 md:grid-cols-2 lg:grid-cols-3'
+
 						>
 							{[
 								{
@@ -383,6 +380,24 @@ const Dashboard = () => {
 												title: 'Curate',
 												link: '/curate',
 												linkText: 'Curate Data'
+											}
+										]
+									: []),
+								...(user?.status === 'ADMIN' || user?.status === 'professor'
+									? [
+											{
+												title: 'Manage Students',
+												link: '/user-management',
+												linkText: 'Approve or Remove Users'
+											}
+										]
+									: []),
+								...(user?.status === 'ADMIN'
+									? [
+											{
+												title: 'Manage Institutions',
+												link: '/institution-management',
+												linkText: 'Add Institutions to Network'
 											}
 										]
 									: [])

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -10,10 +10,7 @@ import {
 	Card,
 	CardBody,
 	Chip,
-	Spinner,
-	Popover,
-	PopoverTrigger,
-	PopoverContent
+	Spinner
 } from '@nextui-org/react';
 import Link from 'next/link';
 import NavBar from '@/components/NavBar';
@@ -22,7 +19,6 @@ import { CardFooter } from '@nextui-org/react';
 import { useUser } from '@/components/UserProvider';
 import { useDisclosure } from '@nextui-org/react';
 import { AuthChecker } from '@/components/AuthChecker';
-import { RiSparklingFill } from 'react-icons/ri';
 import StatusChip from '@/components/StatusChip';
 import { ErrorChecker } from '@/components/ErrorChecker';
 import { EyeIcon, TrashIcon } from '@heroicons/react/24/outline';

--- a/src/pages/user-settings/index.tsx
+++ b/src/pages/user-settings/index.tsx
@@ -330,6 +330,10 @@ const ProfileSettings = () => {
                                   Manage students
                                 </Button>
                               </Link>
+							</>
+						  )}
+						  {(user?.status === "ADMIN") && (
+							<>
                               <Link href="/institution-management">
                                 <Button className="mt-4 w-full text-white bg-[#06B7DB]">
                                   Manage Institutions


### PR DESCRIPTION
This change set adds or removes buttons for Curate, Manage Students, and Manage Institutions to/from the Dashboard and User Account pages as appropriate for admins or faculty.

Before this change set, Curate was only showing for admins, and Manage buttons were not shown for either admin or faculty. Manage Institutions was also incorrectly shown as a button on faculty User Account pages.

This will resolve issue #131.
<img width="2560" height="1386" alt="dashboard fix 1" src="https://github.com/user-attachments/assets/60c36264-6215-4578-839e-8630bff864cf" />
Before (left) and After (right)

<img width="2560" height="1386" alt="dashboard fix 2" src="https://github.com/user-attachments/assets/0c34647e-203b-4b44-955d-50697f8a2747" />
Before (left) and After (right)

<img width="2560" height="1386" alt="dashboard fix 3" src="https://github.com/user-attachments/assets/59537aae-d51d-4e90-a4a8-7dc3941a2210" />
Before (left) and After (right)
