### PR TITLE
table rendering fix

### DIFF
--- a/src/pages/database/characterization_data/[enzyme]/index.tsx
+++ b/src/pages/database/characterization_data/[enzyme]/index.tsx
@@ -1681,29 +1681,18 @@ const DataPage = () => {
                       }}
                       classNames={{
                         th: [
-                          "text-default-500", 
-                          "bg-white", // Solid background to prevent see-through
-                          "font-medium", 
+                          "text-default-500",
+                          "bg-white",
+                          "font-medium",
                           "py-3 px-4",
-                          "before:content-['']",
-                          "before:absolute",
-                          "before:left-0",
-                          "before:top-0",
-                          "before:w-full",
-                          "before:h-full",
-                          "before:bg-default-100/50",
-                          "before:z-[-1]",
+                          // Do not use before:absolute + before:h-full here.
+                          // On Safari, sticky header cells treat that as the full table height,
+                          // so the header background covers every row.
                         ].join(" "),
-                        //base: "overflow-visible",
-                        base: "max-h-[800px] max-w-[1200px] overflow-scroll",
-                        thead: "z-40",
-                        wrapper: "overflow-visible",
+                        base: "max-w-[1200px]",
+                        wrapper: "max-h-[800px] overflow-auto",
+                        thead: "[&>tr]:h-auto",
                         tr: "hover:bg-default-100/50 hover:cursor-pointer hover:shadow-sm hover:rounded-lg",
-                      }}
-                      style={{
-                        position: "sticky",
-                        top: 0,
-                        zIndex: 10
                       }}
                     >
                       <TableHeader>

--- a/src/pages/database/characterization_data/[enzyme]/index.tsx
+++ b/src/pages/database/characterization_data/[enzyme]/index.tsx
@@ -1682,15 +1682,15 @@ const DataPage = () => {
                       classNames={{
                         th: [
                           "text-default-500",
-                          "bg-white",
+                          "bg-gray-100",  // solid background to prevent see-through
                           "font-medium",
                           "py-3 px-4",
                           // Do not use before:absolute + before:h-full here.
                           // On Safari, sticky header cells treat that as the full table height,
                           // so the header background covers every row.
                         ].join(" "),
-                        base: "max-w-[1200px]",
-                        wrapper: "max-h-[800px] overflow-auto",
+                        base: "max-w-[1200px] overflow-scroll",
+                        wrapper: "max-h-[800px] overflow-visible",
                         thead: "[&>tr]:h-auto",
                         tr: "hover:bg-default-100/50 hover:cursor-pointer hover:shadow-sm hover:rounded-lg",
                       }}


### PR DESCRIPTION
sticky header issue + styling issue, safari I think compiles (?) the sticky header different than Chrome/other web browsers and the "sticky" header is a little finicky regardless. Just needed to tweak the styling a bit. Should work across all browsers now. 

Before/after picture. 
<img width="1685" height="925" alt="Screenshot 2026-08-15 at 7 53 21 PM" src="https://github.com/user-attachments/assets/c60314ae-e930-49ba-8b46-15bb4c52f2c5" />

<img width="1673" height="818" alt="Screenshot 2026-08-15 at 8 02 21 PM" src="https://github.com/user-attachments/assets/1a777302-e719-4b97-b1ed-15fc700b2c7c" />
